### PR TITLE
Task/use infowriter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Log interface
+
+## Logger interface
+
+This minimalistic Log interface is aimed to abstract golang loggers into a reduced set of functionality:
+ - Write `Info` to log
+ - Write `Error` to log
+ - Obtain a leveled logger `V`
+
+The only difference between `Info` and `Error` is that the later accepts the error as an explicit parameters. Some developers might consider Error not worth being part of the interface, but it's not uncommon to find loggers that will trigger hooks or use a different formatting for errors than the one used for regular logs.
+
+The leveled logger function at the interface expects to return a copy of the current logger configured to write to the specific log level
+
+## Static functions
+
+In order to use the package import as root for log related functions, and keep usage code clean, a set of static functions will allow you to:
+ - Maintain loggers reference
+ - Target default logger using `Info`, `Error` and `V` functions at the package level
+
+## Design
+
+- Initialization of logs is out of the scope of this interface, that should be managed among the logger implementation and the application using the logger
+- Depending on the log implementation, leveled logs range from not supported, limited, to featurefull. In either case `V` should always return a valid `InfoWriter`.
+- Loggers management from static functions keep all loggers in a map, including the default logger using the string `default` as a key.
+- A `NoLog` implementation has been added to the library. It should be returned when a (leveled) logger is disabled, since if wont output any log.
+

--- a/log.go
+++ b/log.go
@@ -1,15 +1,16 @@
 package log
 
+// KV are key value pairs to be logged
 type KV map[string]interface{}
 
-// Writer for log messages
-type Writer interface {
+// InfoWriter for logs
+type InfoWriter interface {
 	Info(msg string, kv ...KV)
-	Error(err error, msg string, kv ...KV)
 }
 
-// Log messages and errors
+// Logger logs messages and errors
 type Logger interface {
-	Writer
-	V(int) Writer
+	InfoWriter
+	Error(err error, msg string, kv ...KV)
+	V(int) InfoWriter
 }

--- a/nolog.go
+++ b/nolog.go
@@ -10,6 +10,6 @@ func (l *NoLog) Info(msg string, kv ...KV) {}
 func (l *NoLog) Error(err error, msg string, kv ...KV) {}
 
 // V will return its same NoLog instance
-func (l *NoLog) V(int) Writer { return l }
+func (l *NoLog) V(int) InfoWriter { return l }
 
 var _ Logger = (*NoLog)(nil)

--- a/static.go
+++ b/static.go
@@ -46,6 +46,6 @@ func Error(err error, msg string, kv ...KV) {
 }
 
 // V returns a log writter at the specified level
-func V(level int) Writer {
+func V(level int) InfoWriter {
 	return loggers[defaultLogger].V(level)
 }


### PR DESCRIPTION
Leveled logs shouldn't write Errors (errors should always be written)
