### PR TITLE
set KV to struct instead of map

### DIFF
--- a/log.go
+++ b/log.go
@@ -1,7 +1,11 @@
 package log
 
 // KV are key value pairs to be logged
-type KV map[string]interface{}
+// type KV map[string]interface{}
+type KV struct {
+	K string
+	V interface{}
+}
 
 // InfoWriter for logs
 type InfoWriter interface {

--- a/nolog_test.go
+++ b/nolog_test.go
@@ -31,7 +31,7 @@ func TestNoLog(t *testing.T) {
 	nl.Error(
 		errors.New("test error"),
 		"message for test error",
-		KV{"a": "1"}, KV{"b": "2"},
+		KV{"a", "1"}, KV{"b", "2"},
 	)
 	wOut.Close()
 	wErr.Close()


### PR DESCRIPTION
KV might be a bit less appealing when using than a string variadic, but it prevents "non pairs" key values (which might lead to exceptions and panics, depending on the log implementation)

For sure, a variadic of maps was a wrong type for KV pairs